### PR TITLE
Add scripts for downloading and analizing audio

### DIFF
--- a/bird_recordings_duration.py
+++ b/bird_recordings_duration.py
@@ -1,0 +1,76 @@
+import os
+import numpy as np
+from pydub import AudioSegment
+import matplotlib.pyplot as plt
+
+# Mapping Latin bird names to Polish bird names
+polish_names = {
+    "alauda_arvensis": "Skowronek",
+    "erithacus_rubecula": "Rudzik",
+    "parus_major": "Bogatka",
+    "troglodytes_troglodytes": "Strzyżyk",
+    "turdus_merula": "Kos"
+}
+
+# List of folders containing bird recordings
+folders = ["alauda_arvensis", "erithacus_rubecula", "other", "parus_major", "troglodytes_troglodytes", "turdus_merula"]
+
+# Initialize dictionaries to store total durations, average lengths, and standard deviations for each bird species
+durations = {}
+average_lengths = {}
+standard_deviations = {}
+
+def process_folder(folder_path):
+    lengths = []
+    for file in os.listdir(folder_path):
+        file_path = os.path.join(folder_path, file)
+        if file.endswith(".mp3") or file.endswith(".wav"):
+            audio = AudioSegment.from_file(file_path)
+            lengths.append(audio.duration_seconds)
+        elif os.path.isdir(file_path) and folder_path.endswith("other"):
+            lengths += process_folder(file_path)
+    return lengths
+
+print("Processing bird recordings...")
+
+for folder in folders:
+    print(f"Processing folder '{folder}'...")
+    lengths = process_folder(folder)
+
+    # Calculate statistics
+    total_duration = sum(lengths)
+    avg_length = np.mean(lengths)
+    std_deviation = np.std(lengths)
+
+    # Convert the total duration to hours
+    total_duration /= 3600
+    polish_name = polish_names.get(folder, "Inne")
+    durations[polish_name] = total_duration
+    average_lengths[polish_name] = avg_length
+    standard_deviations[polish_name] = std_deviation
+
+    print(f"Total duration for {polish_name}: {total_duration:.2f} hours")
+    print(f"Average length for {polish_name}: {avg_length:.2f} seconds")
+    print(f"Standard deviation for {polish_name}: {std_deviation:.2f} seconds")
+
+print("Finished processing bird recordings.")
+
+# Plot the results
+print("Creating plot...")
+
+fig, ax1 = plt.subplots()
+
+ax1.bar(durations.keys(), durations.values())
+ax1.set_xlabel("Gatunek ptaka")
+ax1.set_ylabel("Czas nagrania (godziny)")
+ax1.set_title("Czas nagrania dla każdego gatunku ptaka")
+
+ax2 = ax1.twinx()
+ax2.plot(list(durations.keys()), list(average_lengths.values()), color='r', marker='o', label='Średnia długość')
+ax2.plot(list(durations.keys()), list(standard_deviations.values()), color='g', marker='o', label='Odchylenie standardowe')
+ax2.set_ylabel("Czas nagrania (sekundy)")
+
+fig.legend(loc="upper right")
+plt.show()
+
+print("Plot displayed.")

--- a/other_spiecies.py
+++ b/other_spiecies.py
@@ -1,0 +1,76 @@
+import requests
+import os
+import random
+
+def get_recordings(query, page=1):
+    url = "https://xeno-canto.org/api/2/recordings"
+    params = {"query": query, "page": page}
+    response = requests.get(url, params=params)
+    return response.json()
+
+def save_audio_file(url, folder, file_name):
+    response = requests.get(url)
+    os.makedirs(folder, exist_ok=True)
+    with open(os.path.join(folder, file_name), "wb") as f:
+        f.write(response.content)
+
+def get_random_species(species_list, num_species, exclude_species):
+    random_species = []
+    while len(random_species) < num_species:
+        species = random.choice(species_list)
+        if species not in exclude_species:
+            random_species.append(species)
+            exclude_species.append(species)
+    return random_species
+
+def get_all_species(recordings):
+    species_list = []
+    for recording in recordings:
+        species = f"{recording['gen']} {recording['sp']}"
+        if species not in species_list:
+            species_list.append(species)
+    return species_list
+
+bird_species = [
+    "troglodytes troglodytes", # Eurasian Wren
+    "turdus merula",           # Common Blackbird
+    "parus major",             # Great Tit
+    "erithacus rubecula",      # European Robin
+    "alauda arvensis"          # Eurasian Skylark
+]
+
+other_species_count = 10
+recordings_per_species = 10
+
+# Fetch the complete list of species
+recordings_result = get_recordings("cnt:poland")
+all_species = get_all_species(recordings_result["recordings"])
+
+# Choose 10 random bird species, excluding those already fetched
+random_species = get_random_species(all_species, other_species_count, bird_species)
+
+for species in random_species:
+    print(f"Fetching recordings for {species}...")
+    page = 1
+    species_folder = f"other/{species.replace(' ', '_')}"
+    recordings_count = 0
+    
+    while recordings_count < recordings_per_species:
+        result = get_recordings(species, page)
+        if not result["recordings"]:
+            break
+            
+        for recording in result["recordings"]:
+            if recordings_count >= recordings_per_species:
+                break
+                
+            file_url = recording["file"]
+            file_name = recording["file-name"]
+            save_audio_file(file_url, species_folder, file_name)
+            recordings_count += 1
+        
+        page += 1
+
+    print(f"{recordings_count} recordings for {species} have been fetched and saved.")
+
+print("Other species' recordings fetched and saved successfully.")


### PR DESCRIPTION
W tym pull requescie dodaję dwa skrypty:

Skrypt do pobierania audio dla kategorii 'other' - Skrypt ten został stworzony na podstawie wcześniejszego kodu służącego do pobierania wszystkich danych. Zmodyfikowałem go, aby pobierał jedynie pliki audio związane z kategorią 'other'. Ze względu na specyfikę projektu i brak potrzeby pobierania innych kategorii na tym etapie, zdecydowałem się nie dodawać wcześniejszego kodu.

Skrypt do analizy długości nagrań - Skrypt ten przechodzi przez wszystkie pliki audio w projekcie i generuje wykres przedstawiający długości nagrań dla każdej kategorii. Analiza ta może pomóc w lepszym zrozumieniu rozkładu długości nagrań w poszczególnych kategoriach, co może być przydatne w dalszych etapach projektu.